### PR TITLE
Showing minimap on hover

### DIFF
--- a/styles/minimap-autohide.less
+++ b/styles/minimap-autohide.less
@@ -6,7 +6,7 @@
 
 atom-text-editor::shadow {
 
-  atom-text-editor-minimap.scrolling {
+  atom-text-editor-minimap.scrolling, atom-text-editor-minimap:hover {
     left: 90%;
     opacity: 1;
   }


### PR DESCRIPTION
This makes `autohide` more compatible with `codeglance` as per #2.
